### PR TITLE
Create an Apache .conf file so / is redirected to the monitoring

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,6 +92,16 @@ class fts::config (
        value => $rest_debug,
        before => Service['httpd'],
        notify => Service['httpd']
-  } 
+  }
+
+  # Enable automatic redirection for the monitoring
+  file{'/etc/httpd/conf.d/ftsmon-redirect.conf':
+      ensure   => present,
+      mode     => '0644',
+      content  => "RewriteEngine On\nRewriteRule ^/$ /fts3/ftsmon/ [R]",
+      before   => Service['httpd'],
+      notify   => Service['httpd'],
+      require  => Package['httpd']
+  }
 }
 


### PR DESCRIPTION
Hi,

Currently, if someone writes http://fts3.cern.ch/ in their browser, they won't get the monitoring,
and guessing the final url is not trivial.
I have added these lines so accessing that url would redirect automatically to http://fts3.cern.ch/fts3/ftsmon/

Regards.
