### PR TITLE
Remove fts-msg-cron.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,7 @@ class fts::config (
                 "set PASSWORD ${msg_password}",
                 "set USERNAME ${msg_username}"
     ],
-    notify  => [Service['fts-msg-bulk'],Service['fts-msg-cron']],
+    notify  => Service['fts-msg-bulk'],
   }
 
   fts3restconfig{'DEFAULT/debug':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,10 +17,6 @@ class fts::service {
     ensure => running,
     enable => true,
   }
-  service{'fts-msg-cron':
-    ensure => running,
-    enable => true,
-  }
   service{'fts-bdii-cache-updater':
     ensure => running,
     enable => true,


### PR DESCRIPTION
fts-msg-cron has been dropped:

https://gitlab.cern.ch/fts/fts3/commit/48bca47ee43529d6c84da30abc7e9dda1f8736cd
